### PR TITLE
adds Home link on each page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,3 +28,7 @@
 .container {
     padding: 2px 16px;
 }
+
+.home_link {
+    color: blue;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   </head>
 
   <h1>
-    <%= link_to "Home",jobs_path, method: :get, class:"home_link"%>
+    <%= link_to "Home",root_path, method: :get, class:"home_link"%>
     </div>
   </h1>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,12 @@
     <%= javascript_importmap_tags %>
   </head>
 
+  <h1>
+    <%= link_to "Home",jobs_path, method: :get, class:"home_link"%>
+    </div>
+  </h1>
+
+
   <body>
     <%= yield %>
   </body>


### PR DESCRIPTION
Link to ticket: https://trello.com/c/UtFWB7WX/6-2-user-can-navigate-to-the-home-page-using-the-nav-bar
Before this PR: There was no link on the header to navigate to the home page

After this PR: 
<img width="1160" alt="image" src="https://github.com/AdamC12/job_tracker/assets/34235034/3508977d-9ad2-41c9-a106-7382897df5b1">
<img width="238" alt="image" src="https://github.com/AdamC12/job_tracker/assets/34235034/2e331657-4b2d-48fe-8939-7ca41ecc7024">

